### PR TITLE
refact: functions are public, rename functions and variables etc.

### DIFF
--- a/mitre_attack_csv.py
+++ b/mitre_attack_csv.py
@@ -1,110 +1,86 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import csv
 import json
+import os
 import requests
 import sys
+from collections import defaultdict
+from typing import NewType, Any, List, Tuple, Dict, DefaultDict, Optional, cast
+
+URL = "https://github.com/mitre/cti/raw/master/enterprise-attack/enterprise-attack.json"
+INPUT_CACHE = 'attack.json'
+OUTPUT_DIR = './attack'
+
+Attack = NewType('Attack', Dict[str, Any])
+Attacks = NewType('Attacks', List[Attack])
+AttackByType = NewType('AttackByType', Dict[str, Attacks])
+Header = NewType('Header', Tuple[str, ...])
 
 
-# tmp_file = 'cache.json'
+def _load_attack() -> Optional[Attack]:
+    try:
+        with open(INPUT_CACHE) as f:
+            return json.load(f)
+    except:
+        return None
 
 
-def _get_input_json():
-    return _get_input_json_from_web()
-    # return _get_input_json_from_cache_file()
+def fetch_attack(url: str) -> Attack:
+    response = requests.get(url)
+    assert (response.status_code == 200), "Failure fetching url"
+    return response.json()
 
 
-def _get_input_json_from_web():
-    print("Fetching latest enterprise-attack.json ...")
-    url = "https://github.com/mitre/cti/raw/master/enterprise-attack/enterprise-attack.json"
-    d = requests.get(url)
-    assert (d.status_code == 200), "Failure fetching url"
-    print("Parsing file ...")
-    return d.json()
+def assert_for_stix(attack: Attack) -> None:
+    assert ('spec_version' in attack), "Failure reading version info in JSON file"
+    assert ('objects' in attack), "Failure reading objects in JSON file"
+    assert (attack['spec_version'] == '2.0'), "Unsupported STIX version"
 
 
-def _get_input_json_from_cache_file():
-    print("Fetching latest enterprise-attack.json from cache file...")
-    with open(tmp_file, 'r') as fp:
-        j = json.load(fp)
-    return j
+def attack_by_type(attack: Attack) -> DefaultDict[str, Attacks]:
+    atttack_by_type: DefaultDict[str, Any] = defaultdict(list)
+    for objects in attack['objects']:
+        if 'type' in objects:
+            atttack_by_type[objects['type']].append(objects)
+    return atttack_by_type
 
 
-def _assert_input_json(j):
-    assert ('spec_version' in j), "Failure reading version info in JSON file"
-    assert ('objects' in j), "Failure reading objects in JSON file"
-    assert (j['spec_version'] == '2.0'), "Unsupported STIX version"
+CODE = re.compile(r'<code>(?P<codeblock>.*?)</code>')
+BOLD = re.compile(r'\*\*(.*?)\*\*')
+LINK = re.compile(r'\[([^[]*?)\]\((.*?)\)')
+HEADER = re.compile('(?:^|\n)#+([^\n]*)')
+MTIL_HTML = re.compile('"https://attack.mitre.org/'
+                       'techniques/(?P<technique>.*?)"')
+MTIL_TEXT = re.compile('https://attack.mitre.org/' +
+                       '(techniques|tactics|software)/(?P<technique>[^\])"]+)')
 
 
-def _get_sdo_by_type(j):
-    d = {}
-    for o_ in j['objects']:
-        if 'type' not in o_:
-            continue
-        type_ = o_['type']
-        if type_ in d:
-            d[type_].append(o_)
-        else:
-            d[type_] = [o_]
-    return d
-
-
-def _get_header(objects):
-    header = ['type', 'id', 'created', 'modified']
-    for o_ in objects:
-        for key in o_.keys():
-            if key not in header:
-                header.append(key)
-    return header
-
-
-def _get_record(key, o_):
-    if key not in o_:
-        return ''
-    v = o_[key]
-    if type(v) == 'str':
-        return v
-    else:
-        return str(v)
-
-
-# minature markdown
-def _minimd(s, fmt="text"):
-
-    code = re.compile('<code>(?P<codeblock>.*?)</code>')
-
-    bold = re.compile('\*\*(.*?)\*\*')
-    link = re.compile('\[([^[]*?)\]\((.*?)\)')
-    header = re.compile('(?:^|\n)#+([^\n]*)')
-
+def minimd(s: str, fmt: str="text") -> str:
+    """minature markdown"""
     if fmt == "html":
-        s = code.sub(
-            lambda x: '<code>{}</code>'.format(x.group('codeblock').replace('<', '&lt;')), s)
-        s = bold.sub(r'<b>\1</b>', s)
-        s = link.sub(r'<a href="\2">\1</a>', s)
-        s = header.sub(r'<b><u>\1</u></b><br/>', s)
+        s = CODE.sub(lambda x: '<code>{}</code>'.format(x.group('codeblock').replace('<', '&lt;')), s)
+        s = BOLD.sub(r'<b>\1</b>', s)
+        s = LINK.sub(r'<a href="\2">\1</a>', s)
+        s = HEADER.sub(r'<b><u>\1</u></b><br/>', s)
 
         # rewrite links to mitre page to this one (mitre to internal link)
-        mtil = re.compile(
-            '"https://attack.mitre.org/techniques/(?P<technique>.*?)"')
-        s = mtil.sub(lambda x: '"#{}"'.format(
+        s = MTIL_HTML.sub(lambda x: '"#{}"'.format(
             x.group('technique').replace('/', '.')), s)
 
         s = s.replace('\n', '<br/>')
 
     elif fmt == "text":
         # tidy headers
-        s = header.sub(r'# \1 #\n', s)
+        s = HEADER.sub(r'# \1 #\n', s)
 
         # neaten code
-        s = code.sub(lambda x: '`{}`'.format(x.group('codeblock')), s)
+        s = CODE.sub(lambda x: '`{}`'.format(x.group('codeblock')), s)
 
         # rewrite links to mitre page to plaintext
-        mtil = re.compile(
-            'https://attack.mitre.org/(techniques|tactics|software)/(?P<technique>[^\])"]+)')
-        s = mtil.sub(lambda x: '{}'.format(
-            x.group('technique').replace('/', '.')), s)
+        #s = MTIL_TEXT.sub(lambda x: '{}'.format(x.group('technique').replace('/', '.')), s)
+        s = MTIL_TEXT.sub(lambda x: x['technique'].replace('/', '.'), s)
 
         # remove <br>
         s = s.replace('<br>', '\n')
@@ -112,30 +88,38 @@ def _minimd(s, fmt="text"):
     return s
 
 
-def _write_csv_file(type_, objects, header):
-    print("Generating CSV file ...(%s)" % (type_))
-    out_file = './output/%s.csv' % (type_)
-    with open(out_file, 'w', newline='\n') as out:
-        writer = csv.DictWriter(
-            out,
-            header,
-            quoting=csv.QUOTE_ALL)
+def make_header(attacks: Attacks) -> Header:
+    names = dict.fromkeys(name for attack in attacks for name in attack)
+    names = dict.fromkeys(['type', 'id', 'created', 'modified', *names])
+    return cast(Header, tuple(names))
+
+
+def get_fields(names: Header, attack: Attack) -> Attack:
+    return cast(Attack, {name: attack.get(name, '') for name in names})
+
+
+def encode(attack: Attack) -> Attack:
+    return cast(Attack, {name: minimd(value) if name == 'description' else value
+                         for name, value in attack.items()})
+
+
+def save_csv(filename: str, attacks: Attacks) -> None:
+    header = make_header(attacks)
+    with open(filename, 'w', newline='\n') as f:
+        writer = csv.DictWriter(f, header, quoting=csv.QUOTE_ALL)
         writer.writeheader()
+        for attack in attacks:
+            writer.writerow(encode(get_fields(header, attack)))
 
-        for o_ in objects:
-            record = {}
-            for key in header:
-                record[key] = _minimd(_get_record(key, o_))
-            writer.writerow(record)
-    return
 
+def main() -> None:
+    print("Fetching latest enterprise-attack.json ...")
+    attack = _load_attack() or fetch_attack(URL)
+    assert_for_stix(attack)
+    os.makedirs(f'{OUTPUT_DIR}', exist_ok=True)
+    for type_, attacks in attack_by_type(attack).items():
+        print(f"Generating CSV file ...({type_})")
+        save_csv(f'{OUTPUT_DIR}/{type_}.csv', attacks)
 
 if __name__ == '__main__':
-    j = _get_input_json()
-    _assert_input_json(j)
-    sdo_d = _get_sdo_by_type(j)
-    for type_ in sdo_d:
-        objects = sdo_d[type_]
-        header = _get_header(objects)
-        _write_csv_file(type_, objects, header)
-    sys.exit(0)
+    main()


### PR DESCRIPTION
1. Functions are as public as possible (so that the same processing as the main function can be called from outside)
2. Constants and functions that can only be used within a module are private (names start with _)
3. Make functions simple so that they can be reused and pass information as arguments
4. Don't print inside the function exclude main function
5. Write the functional description of the function directly under the def statement with triple double quotation marks (specifications can be displayed with the help function)
6. Insert information without omitting the variable name (use the variable name as a comment)
7. Add an underline to the end of the variable name when it conflicts with a reserved word or built-in function name (see PEP8)
8. re.compile constants outside the function (generating each time inside the function is heavy processing)
9. Strings that use backslashes in regular expressions are raw strings (r'...')
.format() and %format strings should be f-strings
10. Use the isinstace function for type comparison using type
11. Using defaultdict makes it easier to separate processing depending on whether there is a dictionary element or not
12. Since str (character string) does not change anything, it is OK to str () all without judging the type by yourself (_get_record function)
13. Define a main function (do not pollute global variables)